### PR TITLE
Fix: ExperienceCard fit content

### DIFF
--- a/app/components/ExperienceCard.tsx
+++ b/app/components/ExperienceCard.tsx
@@ -44,26 +44,28 @@ const ExperienceCard = ({
   return (
     <motion.article
       onClick={() => setExpanded(!expanded)}
+      //TODO: fix width in this animation for tablet and desktop
       animate={{
         width: expanded ? 800 : "calc(100vw - 4rem)",
-        height: expanded ? 800 : "calc(100vw - 4rem)",
+        height: expanded ? 800 : "calc(100vh - 7.5rem)",
       }}
-      className="relative flex flex-col py-6 gap-3 rounded-lg items-center flex-shrink-0
+      //TODO: add border-radius 12px in desktop
+      className="relative flex flex-col py-4 md:py-6 gap-3 rounded-xl items-center flex-shrink-0
     w-full  md:w-[600px] xl:w-[900px] snap-center bg-gray-400/20
      transition-opacity duration-200 overflow-hidden px-3
-     opacity-60 hover:opacity-100"
+     opacity-60 hover:opacity-100 "
     >
       <img
         className="w-[320px] h-[120px] xl:w-[420px] xl:h-[200px] rounded-xl object-cover"
         src={img}
         alt="image"
       />
-      <div className="px-3 md:px-10 space-y-4 mx-1">
-        <h4 className="text-4xl font-light">{title}</h4>
-        <p className="text-lg font-bold uppercase">{subtitle}</p>
+      <div className="px-3 md:px-10 space-y-2 md:space-y-4 mx-1">
+        <h4 className="text-lg md:text-4xl font-light">{title}</h4>
+        <p className="text-md font-bold uppercase">{subtitle}</p>
 
         {isMobile ? (
-          <div className="flex my-2 space-x-2 ml-2 flex-wrap">
+          <div className="flex my-1 space-x-2 ml-2 flex-wrap">
             {techstack.map((tech, index) => (
               <Image
                 key={index}
@@ -93,10 +95,8 @@ const ExperienceCard = ({
         )}
 
         <div className=" space-x-6 flex ml-6 text-gray-300">
-          <p className=" font-extralight text-left">
-            Started work: {startDate}
-          </p>
-          <p className=" font-extralight text-left">Ended: {endDate}</p>
+          <p className=" font-extralight text-left">Start: {startDate}</p>
+          <p className=" font-extralight text-left">End: {endDate}</p>
         </div>
 
         <ul

--- a/app/components/WorkExperience.module.css
+++ b/app/components/WorkExperience.module.css
@@ -1,0 +1,35 @@
+/* https://nextjs.org/docs/basic-features/built-in-css-support#adding-component-level-css */
+
+.Wrapper {
+  height: calc(100vh - 3rem);
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+  justify-content: space-evenly;
+  align-items: center;
+  max-width: 80rem /* 1280px */;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 3rem /* 32px */;
+
+  @media (min-width: 768px) {
+    text-align: left;
+    padding-left: 2.5rem /* 40px */;
+    padding-right: 2.5rem /* 40px */;
+  }
+}
+
+.title {
+  height: 30px;
+  text-transform: uppercase;
+  letter-spacing: 20px;
+  --tw-text-opacity: 1;
+  color: rgb(156 163 175 / var(--tw-text-opacity));
+  font-size: 1rem /* 16px */;
+
+  @media (min-width: 768px) {
+    font-size: 1.5rem /* 24px */;
+  }
+}

--- a/app/components/WorkExperience.tsx
+++ b/app/components/WorkExperience.tsx
@@ -3,15 +3,15 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import ExperienceCard from "./ExperienceCard";
 import { ExperienceCardData } from "../data/ExperienceCardData";
+("");
+import style from "./WorkExperience.module.css";
 
 export default function WorkExperience() {
   const [selectedId, setSelectedId] = useState(null);
 
   return (
     <motion.div
-      className="h-[700px] relative overflow-hidden flex flex-col text-center
-md:text-left  max-w-7xl md:px-10 justify-evenly
-mx-auto items-center pt-6"
+      className={style.Wrapper}
       initial={{
         opacity: 0,
       }}
@@ -21,9 +21,9 @@ mx-auto items-center pt-6"
       viewport={{ once: true }}
       transition={{ duration: 1.5 }}
     >
-      <h3 className="uppercase tracking-[20px] text-gray-400 text-xl ">
-        Experience
-      </h3>
+      <div className={style.title}>
+        <h3>Experience</h3>
+      </div>
 
       <div
         className="w-full flex space-x-5 overflow-x-scroll overflow-y-hidden

--- a/app/data/ExperienceCardData.js
+++ b/app/data/ExperienceCardData.js
@@ -3,8 +3,8 @@ export const ExperienceCardData = [
     img: "/images/sec7team.jpeg",
     title: "Systems Administrator Engineer",
     subtitle: "Tokyo Creation 株式会社",
-    startDate: "Jun 2022",
-    endDate: "Dec 2022",
+    startDate: "Jun 22",
+    endDate: "Dec 22",
     techstack: [
       { src: "/icons/github-icon.svg", url: "https://github.com/" },
 
@@ -66,7 +66,7 @@ export const ExperienceCardData = [
     img: "/images/ArkhonTech.svg",
     title: "Founding Member",
     subtitle: "Arkhon Tech",
-    startDate: "Dec 2021",
+    startDate: "Dec 21",
     endDate: "Present",
     techstack: [
       { src: "/icons/github-icon.svg", url: "https://github.com/" },
@@ -101,8 +101,8 @@ export const ExperienceCardData = [
     img: "/images/bosch.jpg",
     title: "Python Integration Engineer",
     subtitle: "Bosch Japan",
-    startDate: "Nov 2020",
-    endDate: " Oct 2021",
+    startDate: "Nov 20",
+    endDate: " Oct 21",
     techstack: [
       {
         src: "/icons/github-icon.svg",
@@ -149,8 +149,8 @@ export const ExperienceCardData = [
     img: "/images/shopify.svg",
     title: "Store Manager",
     subtitle: "Personal Shopify Store",
-    startDate: "Jun 2019",
-    endDate: "Feb 2020",
+    startDate: "Jun 19",
+    endDate: "Feb 20",
     techstack: [
       {
         src: "/icons/adobe-illustrator.svg",
@@ -177,8 +177,8 @@ export const ExperienceCardData = [
     img: "/images/freelance.png",
     title: "Freelance Web Developer",
     subtitle: "Front-End Web Developer",
-    startDate: "Apr 2019",
-    endDate: "Nov 2020",
+    startDate: "Apr 19",
+    endDate: "Nov 20",
     techstack: [
       {
         src: "/icons/github-icon.svg",


### PR DESCRIPTION
## What is the goal of this pull request

Fix ExperienceCard content style to fit in iPhone Mini screen (375px width)

## What were the changes

- [x] Change font sizes inside card
- [x] Lower spaces between elements inside card
- [x] Add css module as example code in WorkExperience component
- [x] Change date format in ExperienceCardData
- [x] Change start / end text to fit screen
- [ ] Test Snap - couldn't test it in my mobile
- [ ] Fix Tablet width of ExperienceCard
- [ ] Fix border-radius of ExperienceCard in mobile

## Changes in images
Tablet with big width

<img width="586" alt="Screen Shot 2023-03-21 at 09 01 11" src="https://user-images.githubusercontent.com/110560956/226607317-b0b4af1d-e75f-43c8-a973-b706ef2f4e4f.png">

Mobile content fits screen of iPhone SE

<img width="498" alt="Screen Shot 2023-03-21 at 09 01 29" src="https://user-images.githubusercontent.com/110560956/226607328-ba1af201-9195-471b-9fdd-f306d61707ae.png">

Desktop without border-radius

<img width="1082" alt="Screen Shot 2023-03-21 at 09 01 00" src="https://user-images.githubusercontent.com/110560956/226607292-5fb24a78-de0e-4bee-8e69-e157cf463eb1.png">
